### PR TITLE
masked AWS secrets to prevent them being output in plain text in logs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,8 +31,8 @@ type Config struct {
 
 	EnablePrivateEndpoints bool   `envconfig:"ENABLE_PRIVATE_ENDPOINTS"`
 	S3Bucket               string `envconfig:"S3_BUCKET"`
-	AWSAccessKey           string `envconfig:"AWS_ACCESS_KEY_ID"`
-	AWSSecretKey           string `envconfig:"AWS_SECRET_ACCESS_KEY"`
+	AWSAccessKey           string `envconfig:"AWS_ACCESS_KEY_ID" json:"-"`     // Sensitive field which should not be output in JSON.
+	AWSSecretKey           string `envconfig:"AWS_SECRET_ACCESS_KEY" json:"-"` // Sensitive field which should not be output in JSON.
 	LoadSampleData         bool   `envconfig:"LOAD_SAMPLE_DATA"`
 }
 


### PR DESCRIPTION
### What

AWS secrets are output in the application logs on start up. These details are sensitive so we should avoid this. Update `Config` struct applying the json omit tag to omit this field during the json marshall process to prevent this happening.

Also updated unit tests to cover the above.